### PR TITLE
support watchOS and tvOS

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Opus",
+        "repositoryURL": "https://github.com/alta/swift-opus",
+        "state": {
+          "branch": "main",
+          "revision": "7c89270e2aeace13595cd0f8f22141ad0e6e6ea4",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftOgg",
+        "repositoryURL": "https://github.com/vincentneo/SwiftOgg",
+        "state": {
+          "branch": null,
+          "revision": "1d0fc1b44c927c7cdc8e0ce56f382fd6bd945dc7",
+          "version": "1.3.5"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,26 +4,26 @@ import PackageDescription
 let package = Package(
     name: "SwiftOGG",
     platforms: [
-        .iOS(.v10), .macOS(.v10_15),
+        .iOS(.v12), .macOS(.v10_12), .watchOS(.v6), .tvOS(.v12)
     ],
     products: [
         .library(name: "SwiftOGG", targets: ["SwiftOGG"]),
     ],
     dependencies: [
-        .package(
-            name: "YbridOpus",
-            url: "https://github.com/vector-im/opus-swift",
-            from: "0.8.4"),
-        .package(
-            name: "YbridOgg",
-            url: "https://github.com/vector-im/ogg-swift.git",
-            from: "0.8.3")
+        .package(url: "https://github.com/alta/swift-opus", branch: "main"),
+        .package(url: "https://github.com/vincentneo/SwiftOgg", from: "1.3.5")
     ],
     targets: [
         // To debug with a local framework
 //        .binaryTarget(name: "YbridOpus", path: "YbridOpus.xcframework"),
         .target(name: "Copustools", path: "Sources/SupportingFiles/Dependencies/Copustools"),
-        .target(name: "SwiftOGG", dependencies: ["YbridOpus", "YbridOgg", "Copustools"], path: "Sources/SwiftOGG"),
+        .target(name: "SwiftOGG",
+                dependencies: [
+                    .product(name: "Opus", package: "swift-opus"),
+                    .product(name: "COgg", package: "SwiftOgg"),
+                    "Copustools"
+                ],
+                path: "Sources/SwiftOGG"),
         .testTarget(name: "EncoderDecoderTests", dependencies: ["SwiftOGG"], resources: [.process("Resources")]),
     ]
 )

--- a/Sources/SwiftOgg/OGGDecoder.swift
+++ b/Sources/SwiftOgg/OGGDecoder.swift
@@ -15,8 +15,8 @@
  **/
 
 import Foundation
-import YbridOpus
-import YbridOgg
+import Copus
+import COgg
 import Copustools
 
 class OGGDecoder {

--- a/Sources/SwiftOgg/OGGEncoder.swift
+++ b/Sources/SwiftOgg/OGGEncoder.swift
@@ -15,9 +15,13 @@
  **/
 
 import Foundation
+#if canImport(AudioToolbox)
 import AudioToolbox
-import YbridOpus
-import YbridOgg
+#else
+import CoreAudio
+#endif
+import Copus
+import COgg
 
 
 class OGGEncoder {
@@ -159,11 +163,13 @@ class OGGEncoder {
         assemblePages(flush: true)
     }
 
+    #if canImport(AudioToolbox)
     internal func encode(pcm: AudioQueueBuffer) throws {
         let pcmData = pcm.mAudioData.assumingMemoryBound(to: Int16.self)
         try encode(pcm: pcmData, count: Int(pcm.mAudioDataByteSize))
     }
-
+    #endif
+    
     internal func encode(pcm: Data) throws {
         try pcm.withUnsafeBytes { (bytes: UnsafePointer<Int16>) in
             try encode(pcm: bytes, count: pcm.count)

--- a/Sources/SwiftOgg/OpusError.swift
+++ b/Sources/SwiftOgg/OpusError.swift
@@ -16,8 +16,8 @@
 
 import Foundation
 
-import YbridOpus
-import YbridOgg
+import Copus
+import COgg
 
 // MARK: - OpusError
 internal enum OpusError: Error {


### PR DESCRIPTION
Note: this pull request does change the `YbridOpus` and `YbridOgg` dependencies used, as both seem to rely on pre-compiled XCFrameworks that weren't compiled for the two platforms that this pull request aims to provide for. 